### PR TITLE
Add batch_size setting to support for 48GB VRAM platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the official code for the manuscript "Safety Misalignme
 To run the code, ensure you have the following requirements:
 - Disk space: 70 GB
 - RAM: 64 GB (Ours: 256 GB)
-- GPU: NVIDIA GPU with 80 GB of VRAM (Ours: NVIDIA A800 with 80 GB of VRAM)
+- GPU: 1 NVIDIA GPU with 48 GB of VRAM (Ours: NVIDIA A800 with 80 GB of VRAM)
 - OS: Modern x86_64 Linux with `git` and `bash`. (Ours:  Ubuntu 22.04.3, Kernel 6.8.0-40-x86_64, bash 5.1.16)
 - NIVIDA Drivers: 525.60.13+ to support CUDA 12.x. (Ours: 535.104.05)
 - Python: >=3.10, <=3.12.6, with `pip` installed and support for virtual environments (`conda` or `venv`) (Ours: 3.11.9 installed via Miniconda 23.5.2)
@@ -47,7 +47,8 @@ litgpt convert to_litgpt  --checkpoint_dir models/meta-llama/Llama-2-7b-chat-hf
 ```
 ### Update Configurations
 - If the models are stored in a different path, update the corresponding fields of the YAML files in the `configs` folder and Line 6 of the `run.sh` file.
-- If you use a virtual environment provider other than conda or have different environment namings, modify Lines 9-20 of the `run.sh` file to activate your environments appropriately.
+- If you use a virtual environment provider other than conda or have different environment namings, modify Lines 22-34 of the `run.sh` file to activate your environments appropriately.
+- Adjust the training precision and batch sizes in Lines 12-14 based on your VRAM capacity. For example, if you only have 48GB of VRAM instead of 80GB, use the settings in Lines 16-19 instead of those in Lines 12-14.
 - All experiments use a single GPU. If you have multiple GPUs, you can specify which one to use by setting the `CUDA_VISIBLE_DEVICES` environment variable. For example, to use GPU 1 in the current bash, you can run `export CUDA_VISIBLE_DEVICES=1`.
 
 ## Experiment Workflow
@@ -86,6 +87,10 @@ Follow the instructions in the "Installation & Configuration" section.
 
 __[Execution]__  
 Simply run the command `./run.sh E1`.
+
+__[Results]__  
+Results are saved in the `results/E1` folder. The evaluated ASR, ACC, and ACC (LitGPT) are also output to the console. These results generally align with the Llama row of TABLE VI. This indicates that Llama has good safety alignment and performance.
+
 ### Experiment (E2)
 __[3 human-minutes, 15 GPU-minutes]__  
 Attempt to break the safety guardrail of Llama by modifying system prompts, then evaluate the corresponding model harmfulness.
@@ -107,7 +112,6 @@ Results are saved in the `results/E2` folder. The evaluated ASR differences rela
 ### Experiment (E3)
 __[5 human-minutes, 40 GPU-minutes]__  
 Break the safety guardrail of the target model by different fine-tuning methods, then evaluate the safety and utility of the resulting models.
-
 
 __[Preparation]__  
 Ensure that Experiment (E1) has been run.

--- a/run.sh
+++ b/run.sh
@@ -10,13 +10,13 @@ EVAL_HARM_DATASET="strongreject_small"
 
 # For 80GB VRAM
 INFER_HARM_BATCH_SIZE=16
-LM_EVAL_BATCH_SIZE=32
+LM_EVAL_BATCH_SIZE=16
 LITGPT_PRECISION="" # leave it empty to use auto precision, or use `bf16-true` to save VRAM
 
-# For low-resource VRAM
-INFER_HARM_BATCH_SIZE=2
-LM_EVAL_BATCH_SIZE=8
-LITGPT_PRECISION="bf16-true" # leave it empty to use auto precision, or use `bf16-true` to save VRAM
+# For 48GB VRAM
+# INFER_HARM_BATCH_SIZE=4
+# LM_EVAL_BATCH_SIZE=8
+# LITGPT_PRECISION="" # leave it empty to use auto precision, or use `bf16-true` to save VRAM
 
 
 ACTIVATE_PRIMARY_ENV(){

--- a/src/dataset_utils.py
+++ b/src/dataset_utils.py
@@ -25,7 +25,7 @@ BEAVER_TEMPLATE = 'BEGINNING OF CONVERSATION: USER: {prompt} ASSISTANT:'
 QWEN2_TEMPLATE = '''<|im_start|>user
 {prompt}<|im_end|>
 <|im_start|>assistant'''
-ZEPHYR_TEMPLATE = '<|user|>\n{prompt}<\s>\n<|assistant|>\n'
+ZEPHYR_TEMPLATE = '<|user|>\n{prompt}<\\s>\n<|assistant|>\n'
 GEMMA_PROMPT_TEMPLATE = """<start_of_turn>user
 {prompt}<end_of_turn>
 <start_of_turn>model

--- a/src/ssra.py
+++ b/src/ssra.py
@@ -121,7 +121,7 @@ def parse_args():
                         type=int,
                         default=1,
                         help='training epoches')
-    parser.add_argument('--inferbs',
+    parser.add_argument('--infer_bs',
                         type=int,
                         default=10,
                         help='batch size of inference')
@@ -407,7 +407,7 @@ def main():
         sources_sequences = []
         repeat = 1
         expanded_dataset = dataset.loc[dataset.index.repeat(repeat)].reset_index(drop=True)
-        promptsinbatch = 10
+        promptsinbatch = args.infer_bs
         batch_size = promptsinbatch
         column_name = "question"
 
@@ -848,7 +848,7 @@ def main():
         sources_sequences = []
         repeat = 1
         expanded_dataset = dataset.loc[dataset.index.repeat(repeat)].reset_index(drop=True)
-        promptsinbatch = args.inferbs
+        promptsinbatch = args.infer_bs
         batch_size = promptsinbatch
         column_name = "question"
 

--- a/src/ssrd.py
+++ b/src/ssrd.py
@@ -225,6 +225,10 @@ def parse_args():
                         type=str,
                         required=True,
                         help='Model output dir')
+    parser.add_argument('--infer_bs',
+                        type=int,
+                        default=25,
+                        help='Infer batch size')
     parser.add_argument('--infer_output_file',
                         type=str,
                         required=True,
@@ -615,7 +619,7 @@ def main():
             sources_sequences = []
             repeat = 1
             expanded_dataset = dataset.loc[dataset.index.repeat(1)].reset_index(drop=True)
-            promptsinbatch = 25
+            promptsinbatch = args.infer_bs
             batch_size = promptsinbatch*repeat
             column_name = "question"
 
@@ -691,7 +695,7 @@ def main():
             sources_sequences = []
             repeat = 1
             expanded_dataset = dataset.loc[dataset.index.repeat(1)].reset_index(drop=True)
-            promptsinbatch = 5
+            promptsinbatch = args.infer_bs
             batch_size = promptsinbatch*repeat
             column_name = "question"
 


### PR DESCRIPTION
1. Add arguments to specify batch size for `eval_harm.py`, `ssra.py`, `ssrd.py`, and `litgpt eval`.
2. Revise `run.sh` script to allow modification of batch size for limited VRAM.
3. Update `README.md` to instruct users on changing batch size if they have limited VRAM.
4. Added the missing [Result] section for Experiment 1 in `README.md`.
5. Eliminate a warning caused by an inappropriate escape character in `dataset_utils.py`.